### PR TITLE
Use `rsync -aHAX --delete`

### DIFF
--- a/cacher.sh
+++ b/cacher.sh
@@ -10,14 +10,16 @@ if [ -n "$PLUGIN_REBUILD" ]; then
     # Create cache
     for source in "${SOURCES[@]}"; do
         echo "Rebuilding cache for $source..."
-        mkdir -p "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$source" && rsync -aHAX "$source/" "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$source"
+        mkdir -p "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$source" && \
+            rsync -aHAX --delete "$source/" "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$source"
     done
 elif [ -n "$PLUGIN_RESTORE" ]; then
     # Restore from cache
     for source in "${SOURCES[@]}"; do
         if [ -d "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$source" ]; then
             echo "Restoring cache for $source..."
-            mkdir -p "$source" && rsync -aHAX "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$source/" "$source"
+            mkdir -p "$source" && \
+                rsync -aHAX --delete "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$source/" "$source"
         else
             echo "No cache for $source"
         fi


### PR DESCRIPTION
When creating/restoring cache, the user wants the created files and dir to *replace* existing ones. This also implies deleting leftover files.

To be clearer, let's take an example with a JS / TypeScript project:
- A project needs to install some "typings" named `footypes` in   `node_modules`.
- `footypes` becomes deprecated and should be replaced by `footypes2`.   The developer then replaces `footypes` with `footypes2` in his  `package.json`.
- On next builds, old cache is restored (including  `node_modules/footypes`). Then `footypes2` is also installed in  `node_modules`.
- Builds now fail because there are conflicting typings for library  `foo`: both `footypes` and `footypes2` are present.

With the `--delete` flag added to `rsync`, when creating new caches, files that are not present in source dir are deleted from target dir.