### PR TITLE
change cache to operate on a branch-by-branch basis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:latest
 MAINTAINER Michael de Wit <michael@drillster.com>
 
 COPY cacher.sh /usr/local/

--- a/cacher.sh
+++ b/cacher.sh
@@ -6,10 +6,12 @@ if [ -z "$PLUGIN_MOUNT" ]; then
     exit 0
 fi
 
+export CACHE_ID="$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_COMMIT_BRANCH"
+
 if [[ $DRONE_COMMIT_MESSAGE == *"[CLEAR CACHE]"* && -n "$PLUGIN_RESTORE" && "$PLUGIN_RESTORE" == "true" ]]; then
-    if [ -d "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME" ]; then
+    if [ -d "/cache/$CACHE_ID" ]; then
         echo "Found [CLEAR CACHE] in commit message, clearing cache..."
-        rm -rf "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER"
+        rm -rf "/cache/$CACHE_ID/$DRONE_JOB_NUMBER"
         exit 0
     fi
 fi
@@ -25,24 +27,24 @@ if [[ -n "$PLUGIN_REBUILD" && "$PLUGIN_REBUILD" == "true" ]]; then
     for source in "${SOURCES[@]}"; do
         if [ -d "$source" ]; then
             echo "Rebuilding cache for folder $source..."
-            mkdir -p "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source" && \
-                rsync -aHA --delete "$source/" "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source"
+            mkdir -p "/cache/$CACHE_ID/$DRONE_JOB_NUMBER/$source" && \
+                rsync -aHA --delete "$source/" "/cache/$CACHE_ID/$DRONE_JOB_NUMBER/$source"
         elif [ -f "$source" ]; then
             echo "Rebuilding cache for file $source..."
-            rsync -aHA --delete "$source" "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/"
+            rsync -aHA --delete "$source" "/cache/$CACHE_ID/$DRONE_JOB_NUMBER/"
         else
             echo "$source does not exist, removing from cached folder..."
-            rm -rf "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source"
+            rm -rf "/cache/$CACHE_ID/$DRONE_JOB_NUMBER/$source"
         fi
     done
 elif [[ -n "$PLUGIN_RESTORE" && "$PLUGIN_RESTORE" == "true" ]]; then
     # Remove files older than TTL
     if [[ -n "$PLUGIN_TTL" && "$PLUGIN_TTL" > "0" ]]; then
         if [[ $PLUGIN_TTL =~ ^[0-9]+$ ]]; then
-            if [ -d "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER" ]; then
+            if [ -d "/cache/$CACHE_ID/$DRONE_JOB_NUMBER" ]; then
               echo "Removing files and (empty) folders older than $PLUGIN_TTL days..."
-              find "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER" -type f -ctime +$PLUGIN_TTL -delete
-              find "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER" -type d -ctime +$PLUGIN_TTL -empty -delete
+              find "/cache/$CACHE_ID/$DRONE_JOB_NUMBER" -type f -ctime +$PLUGIN_TTL -delete
+              find "/cache/$CACHE_ID/$DRONE_JOB_NUMBER" -type d -ctime +$PLUGIN_TTL -empty -delete
             fi
         else
             echo "Invalid value for ttl, please enter a positive integer. Plugin will ignore ttl."
@@ -50,13 +52,13 @@ elif [[ -n "$PLUGIN_RESTORE" && "$PLUGIN_RESTORE" == "true" ]]; then
     fi
     # Restore from cache
     for source in "${SOURCES[@]}"; do
-        if [ -d "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source" ]; then
+        if [ -d "/cache/$CACHE_ID/$DRONE_JOB_NUMBER/$source" ]; then
             echo "Restoring cache for folder $source..."
             mkdir -p "$source" && \
-                rsync -aHA --delete "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source/" "$source"
-        elif [ -f "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source" ]; then
+                rsync -aHA --delete "/cache/$CACHE_ID/$DRONE_JOB_NUMBER/$source/" "$source"
+        elif [ -f "/cache/$CACHE_ID/$DRONE_JOB_NUMBER/$source" ]; then
             echo "Restoring cache for file $source..."
-            rsync -aHA --delete "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source" "./"
+            rsync -aHA --delete "/cache/$CACHE_ID/$DRONE_JOB_NUMBER/$source" "./"
         else
             echo "No cache for $source"
         fi


### PR DESCRIPTION
I think this is a much better default behavior. Less cache misses when people are working on multiple different branches and each can thrash the cache. 

Let me know if you think this needs to be configurable