### PR TITLE
Fix file cache with subdirectories

### DIFF
--- a/cacher.sh
+++ b/cacher.sh
@@ -29,7 +29,9 @@ if [[ -n "$PLUGIN_REBUILD" && "$PLUGIN_REBUILD" == "true" ]]; then
                 rsync -aHA --delete "$source/" "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source"
         elif [ -f "$source" ]; then
             echo "Rebuilding cache for file $source..."
-            rsync -aHA --delete "$source" "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/"
+            source_dir=$(dirname $source)
+            mkdir -p "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source_dir" && \
+                rsync -aHA --delete "$source" "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source_dir/"
         else
             echo "$source does not exist, removing from cached folder..."
             rm -rf "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source"
@@ -56,7 +58,9 @@ elif [[ -n "$PLUGIN_RESTORE" && "$PLUGIN_RESTORE" == "true" ]]; then
                 rsync -aHA --delete "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source/" "$source"
         elif [ -f "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source" ]; then
             echo "Restoring cache for file $source..."
-            rsync -aHA --delete "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source" "./"
+            source_dir=$(dirname $source)
+            mkdir -p "$source_dir" && \
+                rsync -aHA --delete "/cache/$DRONE_REPO_OWNER/$DRONE_REPO_NAME/$DRONE_JOB_NUMBER/$source" "$source_dir/"
         else
             echo "No cache for $source"
         fi


### PR DESCRIPTION
This PR fixes a bug when using the cache for simple files.

**Current behaviour:**
The file is taken from the specified directory and cached into the /cache/owner/repo/job/ dir
When the restore happens it is again taken from a specified directory and restored to the current working dir (without the subdir context)

Rebuild
consider the following file structure
root.file
subdir/sub.file

```
  restore-cache:
    image: drillster/drone-volume-cache
    restore: true
    mount:
      - root.file
      - subdir/subdir.file
    volumes:
      - /drone/cache:/cache`
```
During rebuild you endup with
/cache/owner/repo/job/root.file
/cache/owner/repo/job/sub.file

**PR:**
This patch first checks for the directory where the file is (using `dirname`), creates it in the cache directory and then rsyncs the file into the subdir (if any)

Same thing happens during restore, first check for the subdir in the project, create it with `mkdir -p`, then restore it using rsync