### PR TITLE
use a .cache_key file if present

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -78,6 +78,28 @@ This would lead to the following cache key if a build is triggered for the maste
 
 In theory you could even use this to share cache between different projects, but extreme caution is advised doing so.
 
+## Using the `.cache_key` file
+Instead of using a `cache_key` option in your Drone yaml file, you may generate a cache key and write it to the `.cache_key` file in the root of your repo. If a `.cache_key` file is present, the first [NAME_MAX](https://www.gnu.org/software/libc/manual/html_node/Limits-for-Files.html) characters of the first line of this file is read and (by default) its MD5 is used as the actual key for sanitization purposes. You may disable MD5'ing by setting `cache_key_disable_sanitize: true`.
+
+This feature allows you to generate the cache key dynamically (e.g. by calculating the checksum of your `package.json`). Note that if a `.cache_key` file is present, it overrides your settings of `cache_key`.
+
+```yaml
+pipeline:
+  build:
+    image: ubuntu
+    commands:
+      - [...]
+      - echo -n "my custom cache key" > .cache_key
+  restore-cache:
+    image: drillster/drone-volume-cache
+    restore: true
+    mount:
+      - ./node_modules
+    # Mount the cache volume, needs "Trusted"
+    volumes:
+      - /tmp/cache:/cache
+```
+
 ## Clearing Cache
 Should you want to clear the cache for a project, you can do so by including `[CLEAR CACHE]` in the commit message. The entire cache folder for the project will be cleared before it is restored. The rebuilding of cache will proceed as normal.
 

--- a/cacher.sh
+++ b/cacher.sh
@@ -28,6 +28,17 @@ if [[ -n "$PLUGIN_CACHE_KEY" ]]; then
     CACHE_PATH=$(join_by / "${CACHE_PATH_VALUES[@]}")
 fi
 
+if [[ -e ".cache_key" ]]; then
+    echo "Found a .cache_key file to be used as the cache path!"
+    CACHE_PATH=$(cut -c-$(getconf NAME_MAX /) .cache_key | head -n 1)
+
+    if [[ -n "$PLUGIN_CACHE_KEY_DISABLE_SANITIZE" && "$PLUGIN_CACHE_KEY_DISABLE_SANITIZE" == "true" ]]; then
+        echo "Warning! .cache_key will be used as-is. Sanitization is your responsibility to make it filename friendly!"
+    else
+        CACHE_PATH=$(echo "$CACHE_PATH" | md5sum | cut -d ' ' -f 1)
+    fi
+fi
+
 IFS=','; read -ra SOURCES <<< "$PLUGIN_MOUNT"
 if [[ -n "$PLUGIN_REBUILD" && "$PLUGIN_REBUILD" == "true" ]]; then
     # Create cache


### PR DESCRIPTION
I added an option to read the cache key from a `.cache_key` file if present. This works very similar to how `.tags` file works with the `drone/docker` plugin.

This way, user can generate the cache key dynamically and in other build steps (currently cache.sh only reads from environment variables which cannot be shared between steps).

I explained in details how it can be used in DOCS.md. I also added an option to skip sanitization (yaml key is `cache_key_disable_sanitize: true`).

This allows for a simulation of how CircleCI caching works. For example:

```yaml
pipeline:
  make cache key:
    image: drillster/drone-volume-cache
    commands:
      - touch .cache_key
      - echo -n $(md5sum package.json)      >> .cache_key
      - echo -n $(md5sum package-lock.json) >> .cache_key
  restore cache:
    image: drillster/drone-volume-cache
    restore: true
    mount: [ node_modules ]
    volumes: [ '/tmp/cache:/cache' ]
```